### PR TITLE
fix: [NON-REQ] overlay write-api for demo

### DIFF
--- a/k8s/api/overlays/demo/patches/virtualService.yaml
+++ b/k8s/api/overlays/demo/patches/virtualService.yaml
@@ -5,3 +5,11 @@
 - op: replace
   path: /spec/gateways/0
   value: iris/iris-ingress-gateway
+
+- op: replace
+  path: /spec/http/0/match/0/uri/prefix
+  value: /write-api
+
+- op: replace
+  path: /spec/http/0/rewrite/uriRegexRewrite/match
+  value: ^/write-api/?(.*)$


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The write API URL is currently baked into the IRIS visualiser image, targeting `write-api`. To avoid rebuilding an image, this a temporary patch to host the write-back API on the `demo` environment on `write-api`.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.