### PR TITLE
fix(DPAV-138): fetch username from identity API on flagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ docker-image:
 	docker build --no-cache -t iris/write-api:latest .
 
 docker-run:
-	docker run -d --name iris-write-api -e PORT=3010 -e DEV=True -e JENA_PROTOCOL=http -e JENA_URL=127.0.0.1 -e JENA_PORT:3030 -p 3010:3010 iris/write-api:latest
+	docker run --rm --name iris-write-api -e PORT=3010 -e DEV=True -e JENA_PROTOCOL=http -e JENA_URL=127.0.0.1 -e JENA_PORT:3030 -p 3010:3010 iris/write-api:latest
 
 run-api:
 	uvicorn api.main:app --reload --port 5021
+
+test:
+	python -m pytest

--- a/api/access.py
+++ b/api/access.py
@@ -13,10 +13,11 @@ class AccessClient:
         self.dev = dev_mode
 
         # Check for the environment variable at startup.
-        self.base_url = os.environ.get('IDENTITY_API_BASE_URL')
-        if not self.base_url:
-            logger.error("IDENTITY_API_BASE_URL environment variable is not set.")
-            raise Exception("IDENTITY_API_BASE_URL environment variable is not set.")
+        if not self.dev:
+            self.identity_api_base_url = os.environ.get('IDENTITY_API_BASE_URL')
+            if not self.identity_api_base_url:
+                logger.error("IDENTITY_API_BASE_URL environment variable is not set.")
+                raise Exception("IDENTITY_API_BASE_URL environment variable is not set.")
 
     def get_user_details(self, headers):
         # If in dev mode, return dummy data.
@@ -25,7 +26,7 @@ class AccessClient:
             return {"username": "Test User1", "user_id": "1234-5678-99ab-cdef"}
         
         # Build the full URL for the API call.
-        url = f"{self.base_url}/api/v1/user-details"
+        url = f"{self.identity_api_base_url}/api/v1/user-details"
         logger.info("Making API call to %s", url)
 
         try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -1030,8 +1030,3 @@ def post_assessment(ass: IesAssessment, req: Request):
 
             return ass.uri
     raise HTTPException(status_code=400, detail="Could not create assessment")
-
-
-# #Create a temporary person for this demo...until we can do something else...
-# person = IesPerson(uri=test_person_uri,givenName = "Test",surname = "User")
-# post_person(person)

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,10 +1,7 @@
 pass_through_headers = [
-    "x-amzn-oidc-data",
-    "x-amzn-oidc-accesstoken",
-    "x-amzn-oidc-identity",
+    "X-Auth-Request-Access-Token",
     "Authorization",
 ]
-
 
 def get_headers(headers):
     forward_headers = {}

--- a/k8s/api/overlays/dev/params.env
+++ b/k8s/api/overlays/dev/params.env
@@ -1,7 +1,8 @@
 JENA_PORT=3030
 JENA_URL=iris-app-graph-server.ia-graph.svc.cluster.local
 JENA_PROTOCOL=http
-DEV=True
+DEV=False
+IDENTITY_API_BASE_URL=https://landing.dev.ndtp.co.uk/
 PORT=3010
 ACCESS_PROTOCOL=https
 ACCESS_URL=ia.dev.ndtp.co.uk

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+os.environ["IDENTITY_API_BASE_URL"] = "https://test.com"
+
+api_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "api"))
+if api_dir not in sys.path:
+    sys.path.insert(0, api_dir)

--- a/unit_tests/test_access.py
+++ b/unit_tests/test_access.py
@@ -1,0 +1,63 @@
+import os
+import pytest
+from api.access import AccessClient
+
+@pytest.fixture
+def connection_string():
+    return "dummy_connection_string"
+
+@pytest.fixture
+def headers():
+    return {
+        "Authorization": "Bearer dummy_token",
+        "X-Auth-Request-Access-Token": "dummy_jwt_token"
+    }
+
+def test_dev_mode_returns_dummy_data(connection_string, headers):
+    client = AccessClient(connection_string, dev_mode=True)
+    result = client.get_user_details(headers)
+    expected = {"username": "Test User1", "user_id": "1234-5678-99ab-cdef"}
+    assert result == expected
+
+def test_api_successful_response(mocker, connection_string, headers):
+    # Create a fake successful response.
+    fake_response = mocker.MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {
+        "content": {
+            "displayName": "Test User",
+            "username": "069292e4-3081-704c-68cd-b5e621f48b62"
+        }
+    }
+    # Patch requests.get in the access module.
+    get_mock = mocker.patch("access.requests.get", return_value=fake_response)
+
+    client = AccessClient(connection_string, dev_mode=False)
+    result = client.get_user_details(headers)
+    expected = {
+        "username": "Test User",
+        "user_id": "069292e4-3081-704c-68cd-b5e621f48b62"
+    }
+    assert result == expected
+
+    # Ensure the API was called with the correct URL and headers.
+    expected_url = "https://test.com/api/v1/user-details"
+    get_mock.assert_called_with(expected_url, headers=headers)
+
+def test_api_error_response(mocker, connection_string, headers):
+    # Create a fake error response from the API.
+    fake_response = mocker.MagicMock()
+    fake_response.status_code = 400
+    fake_response.text = "Bad Request"
+    fake_response.json.return_value = {"error": "Bad Request"}
+    mocker.patch("access.requests.get", return_value=fake_response)
+
+    client = AccessClient(connection_string, dev_mode=False)
+    result = client.get_user_details(headers)
+    assert result == {"error": "Bad Request"}
+
+def test_missing_environment_variable(monkeypatch, connection_string, headers):
+    # Remove the environment variable to simulate a missing configuration.
+    monkeypatch.delenv("IDENTITY_API_BASE_URL", raising=False)
+    with pytest.raises(Exception, match="IDENTITY_API_BASE_URL environment variable is not set"):
+        AccessClient(connection_string, dev_mode=False)

--- a/unit_tests/test_building_flagging.py
+++ b/unit_tests/test_building_flagging.py
@@ -9,6 +9,11 @@ import requests
 from api.routes import router, access_client, run_sparql_update, create_person_insert, InvalidateFlag
 from api.models import IesEntity, EDH, ClassificationEmum
 
+@pytest.fixture(autouse=True)
+def set_identity_api_base_url(monkeypatch):
+    # Set the environment variable for all tests.
+    monkeypatch.setenv("IDENTITY_API_BASE_URL", "https://test.com")
+
 @pytest.fixture
 def client():
     """Create a test client with the router mounted on a FastAPI app."""
@@ -39,9 +44,10 @@ def entity_to_flag():
 # Test data: Invalid flag data with fully qualified URI
 @pytest.fixture
 def invalid_flag_data():
+    edh_instance = EDH(classification=ClassificationEmum.official)
     return InvalidateFlag(
-        flagUri="http://nationaldigitaltwin.gov.uk/data#flag-123",  # Use full URI
-        securityLabel=EDH(classification=ClassificationEmum.official)
+        flagUri="http://nationaldigitaltwin.gov.uk/data#flag-123",
+        securityLabel=edh_instance.model_dump()  # pass a dict instead of an instance
     )
 
 # Common patching for run_sparql_update and access_client.get_user_details

--- a/unit_tests/test_building_retrieval.py
+++ b/unit_tests/test_building_retrieval.py
@@ -5,6 +5,11 @@ from fastapi.testclient import TestClient
 
 from api.routes import router, run_sparql_query
 
+@pytest.fixture(autouse=True)
+def set_identity_api_base_url(monkeypatch):
+    # Set the environment variable for all tests.
+    monkeypatch.setenv("IDENTITY_API_BASE_URL", "https://test.com")
+
 @pytest.fixture
 def client():
     """Create a test client with the router mounted on a FastAPI app."""


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Fetches information about a logged in user when flagging a building from remote API instead of using dummy data.

## Description
Fetches information about a logged in user when flagging a building from remote API instead of using dummy data.

## How Has This Been Tested?
Tested with pytest coverage.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [X] I have added tests to cover my changes.