### PR TITLE
feat(DPAV-324): enable auth against the IA

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -3,6 +3,7 @@ pass_through_headers = [
     "x-amzn-oidc-accesstoken",
     "x-amzn-oidc-identity",
     "Authorization",
+    "x-auth-request-access-token",
 ]
 
 


### PR DESCRIPTION
## NOTE
This PR should be left open as the IA Node Authentication cannot be enabled in its current implementation. Once enabled, this code will be required.

## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
https://ndtp.atlassian.net/browse/DPAV-324

## Description
Ensuring that an additional header is passed into the IA node based upon the injected x-auth-request-access-token.

## How Has This Been Tested?
Tested locally by sending requests to the endpoints with + without the auth token and verifying the response is as expected.

## Checklist:
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.