### PR TITLE
bugfix(non-req): added missing pat token to the cd merge workflow

### DIFF
--- a/.github/workflows/api-cd-pr-merge.yml
+++ b/.github/workflows/api-cd-pr-merge.yml
@@ -53,6 +53,8 @@ jobs:
   api-ci:
     needs: [versioning]
     uses: ./.github/workflows/api-ci-pr.yml
+    secrets:
+      GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
 
   push-to-ECR:
     needs: [api-ci, versioning]


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The PAT token was not being passed to the reusable api-ci workflow which is being run as part of the api-cd-merge workflow.

## Description
<!--- Describe your changes in detail -->
- Passed the PAT token as a secret to the api-ci workflow from the api-cd-merge workflow.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Can only be tested when the workflow is run on merge.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.