### PR TITLE
bugfix(non-req): passed down secrets from the api-cd-merge workflow

### DIFF
--- a/.github/workflows/api-cd-pr-merge.yml
+++ b/.github/workflows/api-cd-pr-merge.yml
@@ -53,8 +53,7 @@ jobs:
   api-ci:
     needs: [versioning]
     uses: ./.github/workflows/api-ci-pr.yml
-    secrets:
-      GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
+    secrets: inherit
 
   push-to-ECR:
     needs: [api-ci, versioning]


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The way to pass down the PAT token was invalid in the previous commit.

## Description
<!--- Describe your changes in detail -->
- Passed down the secrets using the proper way through the inherit value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Can only be tested when the workflow is run

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.