### PR TITLE
bugfix(non-req): added way to pass down secrets to the push to ecr step

### DIFF
--- a/.github/workflows/api-cd-pr-merge.yml
+++ b/.github/workflows/api-cd-pr-merge.yml
@@ -63,3 +63,4 @@ jobs:
       repo_name: "iris/api"
       app_name: "iris/api"
       version: ${{ needs.versioning.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The secrets were not being passed in the push to ECR step which also relied on the api-cr workflow.

## Description
<!--- Describe your changes in detail -->
- Passed down the secrets through the inherit value in the push to ECR step.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested in the previous api-ci step and has worked.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.