### PR TITLE
bugfix(dpav-589): corrected the outh2 signout link

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -935,8 +935,8 @@ def get_signout_links():
         )
         if signout_links_response.status_code == codes.ok:
             return {
-                "oauth2Signout": f"{landing_page_url}/oauth2/signout",
-                "signoutLink": signout_links_response.json(),
+                "oauth2SignoutUrl": f"{landing_page_url}/oauth2/sign_out",
+                "redirectUrl": signout_links_response.json(),
             }
         else:
             return f"Error {signout_links_response.status_code}: {signout_links_response.reason}"


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The oauth2 sign out link was incorrect and resulting in a 503 response being returned from the landing page.

## Description
<!--- Describe your changes in detail -->
- Corrected the oauth2 sign out link from signout to `sign_out`
- Renamed the response variables to be more appropriate.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Resent the correct request through the network tab on the IRIS app which resulted in the sign out.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.