### PR TITLE
bugfix(non-req): added none check for postcode regex search

### DIFF
--- a/api/mappers.py
+++ b/api/mappers.py
@@ -352,8 +352,9 @@ def map_filter_summary_response(results: [FilterableBuildingSchema]) -> FilterSu
     mapped_result: FilterSummary = FilterSummary()
     for result in results:
         post_code_matches = re.search(r"^[0-9A-Z]{3,4}", result.post_code)
-        transformed_post_code = post_code_matches.group()
-        mapped_result.postcode.add(transformed_post_code)
+        if post_code_matches:
+            transformed_post_code = post_code_matches.group()
+            mapped_result.postcode.add(transformed_post_code)
         if result.built_form and len(result.built_form) > 0:
             mapped_result.built_form.add(result.built_form)
         inspection_year = str(result.lodgement_date.year)


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The regex search function in python only returns a match object when a match exists in the provided string. This leads to an error when trying to call the group method of the none object resulting in a 500 server error being returned.

## Description
<!--- Describe your changes in detail 
- Added a none check in case no matches are found for the postcode pattern.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.