### PR TITLE
bugfix(NON-REQ) Do not return 404 on failure of first query

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -492,16 +492,6 @@ def get_building_by_uprn(uprn: str, req: Request):
     building_results = run_sparql_query(
         get_building(uprn), get_forwarding_headers(req.headers)
     )
-    results_bindings = (
-        building_results["results"]["bindings"]
-        if building_results and building_results["results"]
-        else None
-    )
-    if not results_bindings:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Building with UPRN {uprn} not found",
-        )
     roof_results = run_sparql_query(
         get_roof_for_building(uprn), get_forwarding_headers(req.headers)
     )


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Allows fetches of housing where full data is not available

## Description
 - Does not cut out when 1st query does not return anything
 - Should not be throwing 404 as not an appropriate response anyway

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.