### PR TITLE
bugfix(non-req): allowed secrets to be inherited for the release workflow

### DIFF
--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -57,7 +57,6 @@ jobs:
     needs: [versioning]
     uses: ./.github/workflows/api-ci-pr.yml
 
-
   api-push-to-ECR:
     needs: [api-ci, versioning]
     uses: ./.github/workflows/api-cd-push-to-ECR.yml
@@ -66,4 +65,4 @@ jobs:
       repo_name: iris/api
       app_name: iris/api
       version: ${{ needs.versioning.outputs.version }}
-
+      secrets: inherit


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The release workflow was not running successfully due to the `GITHUB_ACCESS_TOKEN` secret not being present.

## Description
<!--- Describe your changes in detail -->
- Added the ability of the release workflow to pass on secrets to reusable workflows.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Have been applied to the api-cd-push-to-ECR workflow so it is working in dev.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.