### PR TITLE
fix(non-req): added secret inheritance to the api ci job in release workflow

### DIFF
--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -56,6 +56,7 @@ jobs:
   api-ci:
     needs: [versioning]
     uses: ./.github/workflows/api-ci-pr.yml
+    secrets: inherit
 
   api-push-to-ECR:
     needs: [api-ci, versioning]


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The api-ci job in the release workflow is missing the secrets inherit setting which is cause the PAT token to not be passed on correctly.

## Description
<!--- Describe your changes in detail -->
- Added the ability to inherit secrets for the api-ci job in the release workflow file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):
API CD PR MERGE workflow working as an example:
![image](https://github.com/user-attachments/assets/9022a625-495d-460e-aac4-09bb3daf105b)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.