### PR TITLE
bugfix(dpav-1285): added code to add non epc buildings to bbox results

### DIFF
--- a/api/mappers.py
+++ b/api/mappers.py
@@ -357,8 +357,9 @@ def map_filter_summary_response(results: [FilterableBuildingSchema]) -> FilterSu
             mapped_result.postcode.add(transformed_post_code)
         if result.built_form and len(result.built_form) > 0:
             mapped_result.built_form.add(result.built_form)
-        inspection_year = str(result.lodgement_date.year)
-        mapped_result.inspection_year.add(inspection_year)
+        if result.lodgement_date:
+            inspection_year = str(result.lodgement_date.year)
+            mapped_result.inspection_year.add(inspection_year)
         if result.fuel_type and len(result.fuel_type) > 0:
             mapped_result.fuel_type.add(result.fuel_type)
         if result.window_glazing and len(result.window_glazing) > 0:

--- a/api/models/dto_models.py
+++ b/api/models/dto_models.py
@@ -175,7 +175,7 @@ class FilterSummary(BaseModel):
     postcode: set[str] = set()
     built_form: set[str] = set()
     inspection_year: set[str] = set()
-    energy_rating: set[str] = set(["EPC In Date", "EPC Expired"])
+    energy_rating: set[str] = {"EPC In Date", "EPC Expired"}
     fuel_type: set[str] = set()
     window_glazing: set[str] = set()
     wall_construction: set[str] = set()

--- a/api/models/dto_models.py
+++ b/api/models/dto_models.py
@@ -141,7 +141,7 @@ class FilterableBuildingSchema(BaseModel):
     uprn: str
     post_code: str
     built_form: Optional[str]
-    lodgement_date: datetime.date
+    lodgement_date: Optional[datetime.date]
     fuel_type: Optional[str]
     window_glazing: Optional[str]
     wall_construction: Optional[str]

--- a/api/query.py
+++ b/api/query.py
@@ -148,8 +148,8 @@ def get_buildings_in_bounding_box_query() -> str:
             fb.toid, fb.point, ea.epc_rating,
             su.type AS structure_unit_type
         FROM filtered_buildings fb
-        JOIN iris.epc_assessment ea ON fb.uprn = ea.uprn
-        JOIN iris.structure_unit su ON ea.id = su.epc_assessment_id;
+        LEFT JOIN iris.epc_assessment ea ON fb.uprn = ea.uprn
+        LEFT JOIN iris.structure_unit su ON ea.id = su.epc_assessment_id;
     """
 
 
@@ -169,8 +169,8 @@ def get_filterable_buildings_in_bounding_box_query() -> str:
             su.roof_construction, su.roof_insulation,
             su.roof_insulation_thickness
         FROM filtered_buildings fb
-        JOIN iris.epc_assessment ea ON fb.uprn = ea.uprn
-        JOIN iris.structure_unit su ON ea.id = su.epc_assessment_id;
+        LEFT JOIN iris.epc_assessment ea ON fb.uprn = ea.uprn
+        LEFT JOIN iris.structure_unit su ON ea.id = su.epc_assessment_id;
     """
 
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The buindings in bbox and filtered building in bbox queries were not returning buildings that did not have an epc assessment. This resulted in the frontend not displaying these building which are crucial aspect of the IRIS application.

## Description
<!--- Describe your changes in detail -->
- Updated the query to fetch building in the bbox to include buildings without an epc
- Updated the query to fetch the filterable buildings in the bbox to include buildings without an epc

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.