### PR TITLE
feature: [DPAV-1456] implement script guard if tables have been loaded previously

### DIFF
--- a/developer-resources/load_gpkg_to_postgis.py
+++ b/developer-resources/load_gpkg_to_postgis.py
@@ -54,7 +54,7 @@ def download_file(url: str, dest: Path):
 
 
     
-def run_db_command(command: str):
+def run_db_command(command: str, fetchone=False):
     conn = psycopg2.connect(
         host=DB_HOST,
         port=DB_PORT,
@@ -65,8 +65,15 @@ def run_db_command(command: str):
     conn.autocommit = True
     with conn.cursor() as cur:
         cur.execute(command)
-    conn.close()    
+        if fetchone:
+            row = cur.fetchone()
+            return row[0] if row else None
+    conn.close()
 
+
+def is_table_populated():
+    count = run_db_command(f"SELECT COUNT(*) FROM {TARGET_SCHEMA}.{TARGET_TABLE};", fetchone=True)
+    return count > 0
 
 def run_ogr2ogr(gpkg_path: Path):
     """Run ogr2ogr to import GPKG into PostGIS."""
@@ -139,30 +146,34 @@ def refresh_data_view():
 
 
 def main():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        if GPKG_SOURCE.endswith('.gpkg'):
-            gpkg_file = Path(tmpdir) / "data.gpkg"
-            download_file(GPKG_SOURCE, gpkg_file)
-            if GPKG_TABLE == "none":
-                run_ogr2ogr(gpkg_file)
-            else:
-                run_ogr2ogr_table(gpkg_file)
-            refresh_materialized_view()          
-        else:
-            zip_file = Path(tmpdir)
-            gpkg_file = Path(tmpdir) / "data.gpkg"
-            download_file(GPKG_SOURCE, zip_file)
-            if GPKG_TABLE == "none":
-                run_ogr2ogr(gpkg_file)
-                  
-            else:
-                run_ogr2ogr_table(gpkg_file)
-                if JOIN_VIEW == "none":
-                    print("no Join")
+    if not is_table_populated():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            if GPKG_SOURCE.endswith('.gpkg'):
+                gpkg_file = Path(tmpdir) / "data.gpkg"
+                download_file(GPKG_SOURCE, gpkg_file)
+                if GPKG_TABLE == "none":
+                    run_ogr2ogr(gpkg_file)
                 else:
-                    refresh_join_view()
-                    refresh_data_view()
-            refresh_materialized_view()
+                    run_ogr2ogr_table(gpkg_file)
+                refresh_materialized_view()          
+            else:
+                zip_file = Path(tmpdir)
+                gpkg_file = Path(tmpdir) / "data.gpkg"
+                download_file(GPKG_SOURCE, zip_file)
+                if GPKG_TABLE == "none":
+                    run_ogr2ogr(gpkg_file)
+                    
+                else:
+                    run_ogr2ogr_table(gpkg_file)
+                    if JOIN_VIEW == "none":
+                        print("no Join")
+                    else:
+                        refresh_join_view()
+                        refresh_data_view()
+                refresh_materialized_view()
+    else:
+        print(f"Table {TARGET_SCHEMA}.{TARGET_TABLE} already populated. Skipping data load.")
+            
 
 
 if __name__ == "__main__":

--- a/developer-resources/load_gpkg_to_postgis.py
+++ b/developer-resources/load_gpkg_to_postgis.py
@@ -142,35 +142,42 @@ def refresh_join_view():
 def refresh_data_view():
     print(f"Refreshing materialized view {DATA_VIEW}")
     run_db_command(f"REFRESH MATERIALIZED VIEW {DATA_VIEW};")
-    print("Materialized view refresh complete.")    
+    print("Materialized view refresh complete.")
+
+
+def handle_geopackage(tmpdir):
+    gpkg_file = Path(tmpdir) / "data.gpkg"
+    download_file(GPKG_SOURCE, gpkg_file)
+    if GPKG_TABLE == "none":
+        run_ogr2ogr(gpkg_file)
+    else:
+        run_ogr2ogr_table(gpkg_file)
+    
+
+def handle_zip(tmpdir):
+    zip_file = Path(tmpdir)
+    gpkg_file = Path(tmpdir) / "data.gpkg"
+    download_file(GPKG_SOURCE, zip_file)
+    if GPKG_TABLE == "none":
+        run_ogr2ogr(gpkg_file)
+    else:
+        run_ogr2ogr_table(gpkg_file)
+        if JOIN_VIEW == "none":
+            print("no Join")
+        else:
+            refresh_join_view()
+            refresh_data_view()
+    
 
 
 def main():
     if not is_table_populated():
         with tempfile.TemporaryDirectory() as tmpdir:
             if GPKG_SOURCE.endswith('.gpkg'):
-                gpkg_file = Path(tmpdir) / "data.gpkg"
-                download_file(GPKG_SOURCE, gpkg_file)
-                if GPKG_TABLE == "none":
-                    run_ogr2ogr(gpkg_file)
-                else:
-                    run_ogr2ogr_table(gpkg_file)
-                refresh_materialized_view()          
+                handle_geopackage(tmpdir)       
             else:
-                zip_file = Path(tmpdir)
-                gpkg_file = Path(tmpdir) / "data.gpkg"
-                download_file(GPKG_SOURCE, zip_file)
-                if GPKG_TABLE == "none":
-                    run_ogr2ogr(gpkg_file)
-                    
-                else:
-                    run_ogr2ogr_table(gpkg_file)
-                    if JOIN_VIEW == "none":
-                        print("no Join")
-                    else:
-                        refresh_join_view()
-                        refresh_data_view()
-                refresh_materialized_view()
+                handle_zip(tmpdir)
+            refresh_materialized_view()
     else:
         print(f"Table {TARGET_SCHEMA}.{TARGET_TABLE} already populated. Skipping data load.")
             


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the load_gpkg_to_postgis.py script always truncates and loads the tables. However, this means everytime a new pod is run, an expensive process to load the tables is undertaken. 

## Description
<!--- Describe your changes in detail -->
Implement a guard in the script where a load is not run if data exists in the table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
