### PR TITLE
feat(dpav-1684): only included the roof aspect area when the value is > 0

### DIFF
--- a/api/mappers.py
+++ b/api/mappers.py
@@ -530,41 +530,49 @@ def _add_roof_aspect_area_direction_filter(
 ):
     if (
         roof_aspect_area_facing_north_m2
+        and roof_aspect_area_facing_north_m2 > 0
         and "North" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("North")
     if (
         roof_aspect_area_facing_north_east_m2
+        and roof_aspect_area_facing_north_east_m2 > 0
         and "NorthEast" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("NorthEast")
     if (
         roof_aspect_area_facing_north_west_m2
+        and roof_aspect_area_facing_north_west_m2 > 0
         and "NorthWest" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("NorthWest")
     if (
         roof_aspect_area_facing_south_m2
+        and roof_aspect_area_facing_south_m2 > 0
         and "South" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("South")
     if (
         roof_aspect_area_facing_south_east_m2
+        and roof_aspect_area_facing_south_east_m2 > 0
         and "SouthEast" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("SouthEast")
     if (
         roof_aspect_area_facing_south_west_m2
+        and roof_aspect_area_facing_south_west_m2 > 0
         and "SouthWest" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("SouthWest")
     if (
         roof_aspect_area_facing_east_m2
+        and roof_aspect_area_facing_east_m2 > 0
         and "East" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("East")
     if (
         roof_aspect_area_facing_west_m2
+        and roof_aspect_area_facing_west_m2 > 0
         and "West" not in filter_summary.roof_aspect_area_direction
     ):
         filter_summary.roof_aspect_area_direction.add("West")


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All 8 roof aspect area facing directions were showing up when there was no useful data for it in the buildings i.e. when it was 0.

## Description
<!--- Describe your changes in detail -->
- Added an extra check to check if the roof aspect area facing direction value is > 0 to include the relevant direction facing in the filter summary list

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
