### PR TITLE
feature(DPAV-1731): efficiency improvements to migration queries

### DIFF
--- a/api/alembic/versions/0e6126841f0c_015_update_buildings_is_residential.py
+++ b/api/alembic/versions/0e6126841f0c_015_update_buildings_is_residential.py
@@ -27,6 +27,14 @@ def upgrade() -> None:
     
     op.execute(
         """
+        CREATE INDEX idx_structure_unit_uprn_not_null
+            ON iris.structure_unit (uprn)
+            WHERE uprn IS NOT NULL;
+        """
+    )
+    
+    op.execute(
+        """
         ALTER TABLE iris.building ADD COLUMN "is_residential" BOOLEAN not null DEFAULT false;
         """
     )
@@ -34,16 +42,21 @@ def upgrade() -> None:
     op.execute(
         """
         UPDATE iris.building AS b
-        SET is_residential =
-              EXISTS (
+        SET is_residential = TRUE
+              WHERE EXISTS (
+                  SELECT 1 FROM iris.epc_assessment AS ea
+                  WHERE ea.uprn = b.uprn);
+    """
+    )
+    
+    op.execute(
+        """
+           UPDATE iris.building AS b
+           SET is_residential = TRUE
+           WHERE is_residential = FALSE AND EXISTS (
                   SELECT 1
-                  FROM iris.epc_assessment AS ea
-                  WHERE ea.uprn = b.uprn
-              )
-           OR EXISTS (
-                  SELECT 1
-                  FROM iris.structure_unit AS su2
-                  WHERE su2.uprn = b.uprn
+                  FROM iris.structure_unit AS su
+                  WHERE su.uprn = b.uprn
               );
         """
     )
@@ -58,3 +71,8 @@ def downgrade() -> None:
         """
     )
     
+    op.execute(
+        """
+        DROP INDEX IF EXISTS iris.idx_structure_unit_uprn_not_null;
+        """
+    )

--- a/api/alembic/versions/473ce669077d_016_update_buildings_epc_is_residential.py
+++ b/api/alembic/versions/473ce669077d_016_update_buildings_epc_is_residential.py
@@ -65,7 +65,8 @@ def upgrade() -> None:
         FROM iris.building a
         LEFT JOIN iris.epc_assessment b
           ON a.uprn = b.uprn
-        WHERE a.is_residential IS TRUE;
+        WHERE a.is_residential IS TRUE
+        WITH NO DATA;
         """
     )
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [x ] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Run `make test` to run all tests and checks--->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->

- is_residential query split into two as you suggested
- iris.building_epc view creation now runs with no data instead of with
- index created for iris.structure_unit(uprn) to further reduce is_residential query time (this already exists for iris.epc_assessment)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Tested alembic downgrade back to cc816c325e2a migration and then a full upgrade from there. 

<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
- [ ] I have included my changes in the unreleased section of the changelog.
